### PR TITLE
fix failing python2.7 building

### DIFF
--- a/core/python2ActionLoop/Dockerfile
+++ b/core/python2ActionLoop/Dockerfile
@@ -42,6 +42,7 @@ RUN apk add --no-cache \
         bash \
         build-base \
         bzip2-dev \
+        curl \
         gcc \
         libc-dev \
         libxslt-dev \
@@ -69,7 +70,7 @@ RUN pip install --no-cache-dir --upgrade pip setuptools six \
         signalfx_lambda==0.2.1
 
 # install nim
-RUN curl https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh | bash
+RUN curl https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh | sed -e 's/--directory/-d/g'| bash
 
 RUN mkdir -p /action
 WORKDIR /

--- a/core/python2ActionLoop/Dockerfile
+++ b/core/python2ActionLoop/Dockerfile
@@ -40,6 +40,7 @@ ARG GO_PROXY_BUILD_FROM=source
 # Upgrade and install basic Python dependencies
 RUN apk add --no-cache \
         bash \
+        build-base \
         bzip2-dev \
         gcc \
         libc-dev \


### PR DESCRIPTION
- add curl and base-build package
- fix failing greenlet building (due to pip 21 end of support on python 2.7 EOL?)
- use `-d` flag in `nim-install-linux.sh` instead of `--directory` (due to an alpine's mktemp limitation)