### PR TITLE
Remove OW_EXECUTION_ENV variable

### DIFF
--- a/core/python2ActionLoop/Dockerfile
+++ b/core/python2ActionLoop/Dockerfile
@@ -86,6 +86,4 @@ ENV OW_COMPILER=/bin/compile
 ENV OW_LOG_INIT_ERROR=1
 # the launcher must wait for an ack
 ENV OW_WAIT_FOR_ACK=1
-# using the runtime name to identify the execution environment
-ENV OW_EXECUTION_ENV=openwhisk/action-python-v2.7
 ENTRYPOINT ["/bin/proxy"]

--- a/core/python3ActionLoop/Dockerfile
+++ b/core/python3ActionLoop/Dockerfile
@@ -58,8 +58,6 @@ ADD lib/launcher.py /lib/launcher.py
 ENV OW_LOG_INIT_ERROR=1
 # the launcher must wait for an ack
 ENV OW_WAIT_FOR_ACK=1
-# using the runtime name to identify the execution environment
-ENV OW_EXECUTION_ENV=openwhisk/action-python-v3.7
 # compiler script
 ENV OW_COMPILER=/bin/compile
 

--- a/core/python3AiActionLoop/Dockerfile
+++ b/core/python3AiActionLoop/Dockerfile
@@ -90,8 +90,6 @@ ADD lib/launcher.py /lib/launcher.py
 ENV OW_LOG_INIT_ERROR=1
 # the launcher must wait for an ack
 ENV OW_WAIT_FOR_ACK=1
-# using the runtime name to identify the execution environment
-ENV OW_EXECUTION_ENV=openwhisk/action-python-v3.6-ai
 # compiler script
 ENV OW_COMPILER=/bin/compile
 # use utf-8


### PR DESCRIPTION
The title says most of it.  The variable is removed from all three Dockerfiles.  The presence of the variable triggers a check in the go proxy that will fail for generic actions that are not going through the normal compile-then-execute sequence.    We have decided the easiest source is to remove the variables (which disables the check).   The same has been done for the go 1.15 runtime.