### PR TITLE
Fix compile script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ deploy:
   - provider: script
     script: "./tools/travis/publish.sh nimbella 3 nightly && ./tools/travis/publish.sh nimbella 3-ai nightly"
     on:
-      branch: dev-2020-10-10
+      branch: dev
       repo: nimbella-corp/openwhisk-runtime-python

--- a/core/python2ActionLoop/bin/compile
+++ b/core/python2ActionLoop/bin/compile
@@ -71,7 +71,8 @@ else echo "Execution Environment Mismatch"
      exit 1
 fi
 """, True)
-    write_file("%s.env"%tgt_file, os.environ['__OW_EXECUTION_ENV'])
+     if os.environ.get("__OW_EXECUTION_ENV"):
+       write_file("%s.env"%tgt_file, os.environ['__OW_EXECUTION_ENV'])
     return tgt_file
 
 #check if a module exists

--- a/core/python2ActionLoop/bin/compile
+++ b/core/python2ActionLoop/bin/compile
@@ -71,8 +71,8 @@ else echo "Execution Environment Mismatch"
      exit 1
 fi
 """, True)
-     if os.environ.get("__OW_EXECUTION_ENV"):
-       write_file("%s.env"%tgt_file, os.environ['__OW_EXECUTION_ENV'])
+    if os.environ.get("__OW_EXECUTION_ENV"):
+      write_file("%s.env"%tgt_file, os.environ['__OW_EXECUTION_ENV'])
     return tgt_file
 
 #check if a module exists

--- a/core/python3ActionLoop/bin/compile
+++ b/core/python3ActionLoop/bin/compile
@@ -73,7 +73,8 @@ else echo "Execution Environment Mismatch"
      exit 1
 fi
 """, True)
-    write_file("%s.env"%tgt_file, os.environ['__OW_EXECUTION_ENV'])
+    if os.environ.get("__OW_EXECUTION_ENV"):
+      write_file("%s.env"%tgt_file, os.environ['__OW_EXECUTION_ENV'])
     return tgt_file
 
 #check if a module exists

--- a/core/python3AiActionLoop/bin/compile
+++ b/core/python3AiActionLoop/bin/compile
@@ -73,7 +73,8 @@ else echo "Execution Environment Mismatch"
      exit 1
 fi
 """, True)
-    write_file("%s.env"%tgt_file, os.environ['__OW_EXECUTION_ENV'])
+    if os.environ.get("__OW_EXECUTION_ENV"):
+      write_file("%s.env"%tgt_file, os.environ['__OW_EXECUTION_ENV'])
     return tgt_file
 
 #check if a module exists


### PR DESCRIPTION
Fixes an error in the previous change to this runtime to not set the OW_EXECUTION_ENV environment variable.  A supporting change int the compile script turns out to be necessary.