### PR TITLE
Updating Python SDK to latest release.

### DIFF
--- a/core/python36AiAction/requirements.txt
+++ b/core/python36AiAction/requirements.txt
@@ -12,7 +12,7 @@ twisted == 19.10.0
 netifaces == 0.10.9
 
 # Nimbella package
-nimbella == 1.0.0
+nimbella == 2.1.1
 
 # package to sync from a variety of cloud blob storage
 python-rclone == 0.0.2

--- a/core/python39Action/requirements.txt
+++ b/core/python39Action/requirements.txt
@@ -16,7 +16,7 @@ python-rclone == 0.0.2
 google-cloud-storage == 1.35.1
 
 # Nimbella package
-nimbella == 2.0.0
+nimbella == 2.1.1
 
 # Etc
 pymongo == 3.11.4

--- a/core/python3Action/requirements.txt
+++ b/core/python3Action/requirements.txt
@@ -16,7 +16,7 @@ python-rclone == 0.0.2
 google-cloud-storage == 1.28.1
 
 # Nimbella package
-nimbella == 1.0.0
+nimbella == 2.1.1
 
 # Etc
 pymongo == 3.10.1


### PR DESCRIPTION
I've just released a new version of the SDK: https://github.com/nimbella/nimbella-sdk-python/runs/3262064136?check_suite_focus=true

There's a queston on whether we should lock the Python SDK to an explicit version (as happens now) or just allow patch/minor updates automatically? I'd vote for allowing patch and minor updates as it saves us having to manually do changes like this every time (which will probably be missed occassionally). 